### PR TITLE
refact: Record 엔티티에 memberId 대신 UserIdx 추가 -> 그에 따라 Controller, Repos…

### DIFF
--- a/src/main/java/com/example/webserver/controller/AiResultController.java
+++ b/src/main/java/com/example/webserver/controller/AiResultController.java
@@ -1,16 +1,20 @@
 package com.example.webserver.controller;
 
 import com.example.webserver.dto.AiResultDto;
+import com.example.webserver.entity.Record;
 import com.example.webserver.service.RecordService;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/ai")
@@ -24,16 +28,17 @@ public class AiResultController {
     @PostMapping("/results")
     public ResponseEntity<String> receiveAIResult(@RequestBody AiResultDto resultDto) {
         try {
-            String userIdx = resultDto.getUserIdx(); // 사용자 식별
-            String recordIdx = resultDto.getRecordIdx();    // 기록 식별
+            String recordIdx = resultDto.getRecordIdx();  // 기록 식별
             String result = resultDto.getResult();  // AI 결과값
 
             // Record 업데이트 (resultTime 및 deviceType 저장)
-            boolean isUpdated = recordService.updateRecordWithAIResult(recordIdx, result);
-            if (!isUpdated) {
-                log.warn("Record with recordIdx {} not found", recordIdx);
-                return ResponseEntity.status(404).body("Record not found");
+            if (!recordService.updateRecordWithAIResult(recordIdx, result)) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Record with recordIdx " + recordIdx + " not found.");
             }
+
+            // recordIdx 에 해당하는 기록의 userIdx 찾기 -> websocket 의 경로에 필요
+            Optional<Record> optionalRecord = recordService.getRecordByRecordIdx(recordIdx);
+            String userIdx = optionalRecord.get().getUserIdx();
 
             // WebSocket 경로로 메시지 전송
             String destination = "/socket/" + userIdx;

--- a/src/main/java/com/example/webserver/controller/RecordController.java
+++ b/src/main/java/com/example/webserver/controller/RecordController.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 public class RecordController {
     private final RecordService recordService;
 
+    /*
     @PostMapping("/records")
     public ResponseEntity<Record> saveRecord(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestParam("file")MultipartFile file) throws Exception {
         Record record = recordService.saveRecord(userDetails, file);
@@ -34,10 +35,12 @@ public class RecordController {
         return ResponseEntity.ok(records);
     }
 
+     */
+
     // 음성파일 백앤드에서 받아서 recordIdx, time 저장 후 ai 넘겨줌
     @PostMapping("/input")
     public ResponseEntity<Record> fileInput(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestParam("file") MultipartFile file) throws Exception {
-        Record record = recordService.fileInput(userDetails, file);
+        Record record = recordService.fileInput(userDetails.getUsername(), file);
         return ResponseEntity.ok(record);
     }
 
@@ -58,6 +61,6 @@ public class RecordController {
     // 클라이언트가 알림 확인 시 checked -> true 로 업데이트
     @PatchMapping("/records/{id}/checked")
     public ResponseEntity<?> updateCheckedStatus(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable String id) {
-        return recordService.updateCheckedStatus(userDetails, id);
+        return recordService.updateCheckedStatus(userDetails.getUsername(), id);
     }
 }

--- a/src/main/java/com/example/webserver/dto/AiResultDto.java
+++ b/src/main/java/com/example/webserver/dto/AiResultDto.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class AiResultDto {
-    private String userIdx;
     private String recordIdx;
     private String result;
 }

--- a/src/main/java/com/example/webserver/entity/Record.java
+++ b/src/main/java/com/example/webserver/entity/Record.java
@@ -19,7 +19,7 @@ public class Record {
 
     private String recordIdx;
 
-    private String memberId;
+    private String userIdx;
 
     private String deviceType;
 
@@ -29,8 +29,8 @@ public class Record {
 
     private boolean checked;    // 알림 확인 유무
 
-    public Record(String memberId, String deviceType, LocalDateTime time) {
-        this.memberId = memberId;
+    public Record(String userIdx, String deviceType, LocalDateTime time) {
+        this.userIdx = userIdx;
         this.deviceType = deviceType;
         this.time = time;
         this.checked = false;

--- a/src/main/java/com/example/webserver/login/CustomUserDetailsService.java
+++ b/src/main/java/com/example/webserver/login/CustomUserDetailsService.java
@@ -19,6 +19,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
+    // 로그인 시에 DB 에서 유저 정보와 권한 정보를 가져와서 해당 정보를 기반으로 CustomUserDetails 객체를 생성해 리턴
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         return memberRepository.findByUsername(username)
@@ -26,7 +27,8 @@ public class CustomUserDetailsService implements UserDetailsService {
                 .orElseThrow(() -> new UsernameNotFoundException("해당하는 회원을 찾을 수 없습니다."));
     }
 
-    // 해당하는 User 의 데이터가 존재한다면 UserDetails 객체로 만들어서 return
+    // DB 에 있는 사용자의 아이디와 비밀번호를 담고 있는 CustomUserDetails 생성
+    // -> authenticationManager 가 이 객체와 UsernamePasswordAuthenticationToken 과 비교하여 사용자 인증을 해줌
     private UserDetails createUserDetails(Member member) {
         return CustomUserDetails.builder()
                 .idx(member.getIdx())

--- a/src/main/java/com/example/webserver/login/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/webserver/login/JwtAuthenticationFilter.java
@@ -23,7 +23,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
         // 1. Request Header에서 JWT 토큰 추출
         String token = resolveToken((HttpServletRequest) request);
 
-        // 2. validateToken으로 토큰 유효성 검사
+        // 2. validateToken(토큰 정보를 검증하는 메서드)으로 토큰 유효성 검사
         if (token != null && jwtTokenProvider.validateToken(token)) {
             // 토큰이 유효할 경우 토큰에서 Authentication 객체를 가지고 와서 SecurityContext에 저장
             Authentication authentication = jwtTokenProvider.getAuthentication(token);

--- a/src/main/java/com/example/webserver/login/JwtTokenProvider.java
+++ b/src/main/java/com/example/webserver/login/JwtTokenProvider.java
@@ -83,7 +83,7 @@ public class JwtTokenProvider {
         CustomUserDetails principal = CustomUserDetails.builder()
                 .idx(claims.get("idx", String.class)) // idx 추가
                 .username(claims.getSubject())
-                .password("") // 비밀번호는 포함하지 않음
+                .password("") // 비밀번호는 포함하지 않음 -> 아이디와 비밀번호가 아닌 jwt로 사용자를 구별
                 .roles(authorities.stream()
                         .map(GrantedAuthority::getAuthority)
                         .collect(Collectors.toList()))

--- a/src/main/java/com/example/webserver/repository/RecordRepository.java
+++ b/src/main/java/com/example/webserver/repository/RecordRepository.java
@@ -10,14 +10,12 @@ import java.util.Optional;
 
 @Repository
 public interface RecordRepository extends MongoRepository<Record, String> {
-    public List<Record> findAllByMemberId(String memberId);
-
     // ai 모델 결과 받고 저장 시에 recordIdx 로 기록 찾음
     public Optional<Record> findByRecordIdx(String recordIdx);
 
     // checked 가 false 인 Record 반환 -> 클라이언트가 아직 확인하지 못한 알림
-    public List<Record> findAllByMemberIdAndCheckedIsFalse(String memberId);
+    public List<Record> findAllByUserIdxAndCheckedIsFalse(String userIdx);
 
     // 해당 날짜의 deviceType 별로 Record 조회
-    public List<Record> findAllByMemberIdAndDeviceTypeAndResultTimeBetween(String memberId, String deviceType, LocalDateTime startDate, LocalDateTime endDate);
+    public List<Record> findAllByUserIdxAndDeviceTypeAndTimeBetween(String userIdx, String deviceType, LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/com/example/webserver/service/MemberService.java
+++ b/src/main/java/com/example/webserver/service/MemberService.java
@@ -54,10 +54,14 @@ public class MemberService {
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(username, password);
         log.info("Step 1: AuthenticationToken Generate - username: {}", username);
 
-        // 2. authenticate() 메서드 실행 (CustomUserDetailsService.loadUserByUsername 호출)
+        // authenticationManager 가 사용자 인증을 진행해 주는데 로그인 정보와 DB에 있는 사용자 정보를 비교하기 위해
+        // UserDetailsService 에 있는 loadUserByUsername 메서드를 내부적으로 '알아서' 호출해서
+        // 사용자를 인증한 후 성공하면(db에 있는 유저의 아이디, 비밀번호와 입력받은 로그인 정보가 일치하면) Authentication 객체를 반환
+        // 2. authenticationManager -> authenticate() 메서드 실행 (CustomUserDetailsService.loadUserByUsername 호출)
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
         log.info("Step 2: Authentication Success - isAuthenticated: {}", authentication.isAuthenticated());
         log.info("{}", authentication);
+        // 사용자 인증이 끝나고 Authentication 이 성공적으로 반환되었다면 이를 SecurityContextHolder 에 저장 -> 내부적으로 실행
 
         // 3. 인증 정보를 기반으로 JWT 토큰 생성
         JwtToken jwtToken = jwtTokenProvider.generateToken(authentication);

--- a/src/main/java/com/example/webserver/service/RecordService.java
+++ b/src/main/java/com/example/webserver/service/RecordService.java
@@ -1,7 +1,9 @@
 package com.example.webserver.service;
 
+import com.example.webserver.entity.Member;
 import com.example.webserver.entity.Record;
 import com.example.webserver.login.CustomUserDetails;
+import com.example.webserver.repository.MemberRepository;
 import com.example.webserver.repository.RecordRepository;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -23,6 +25,7 @@ import java.util.Optional;
 public class RecordService {
     private static final Logger log = LoggerFactory.getLogger(RecordService.class);
     private final RecordRepository recordRepository;
+    private final MemberRepository memberRepository;
     private final SimpMessagingTemplate messagingTemplate;
     private final CounterService counterService;
 
@@ -37,7 +40,7 @@ public class RecordService {
         return deviceType;
     }
 
-
+/*
     public Record saveRecord(CustomUserDetails userDetails, MultipartFile file) throws Exception {
 
         String deviceType = classifySound(file);
@@ -55,14 +58,24 @@ public class RecordService {
         return record;
     }
 
+ */
+
     private String callAiModel(MultipartFile file, String url) {
         // AI 모델 호출 및 결과 반환
         // HTTP Client 라이브러리 필요 (예: RestTemplate, WebClient 등)
         return "세탁기"; // 샘플 반환값
     }
 
+    public Optional<Record> getRecordByRecordIdx(String recordIdx) {
+        return recordRepository.findByRecordIdx(recordIdx);
+    };
+
+    public Optional<Member> getMemberByUsername(String username) {
+        return memberRepository.findByUsername(username);
+    };
+
     // 음성 -> 백앤드 -> ai 모델
-    public Record fileInput(CustomUserDetails userDetails, MultipartFile file) throws Exception {
+    public Record fileInput(String username, MultipartFile file) throws Exception {
         // 자동 증가 recordIdx 생성
         long recordIdx = counterService.getNextRecordIdxSequence("record_idx");
 
@@ -72,14 +85,17 @@ public class RecordService {
         // AI 모델 호출 로직 (샘플로 REST 호출 방식 사용) ... 이후 추가 해야함 지금은 생략
         String aiModelUrl = "http://ai-model-service/analyze";
 
+        // username 으로 member 에서 userIdx(idx) 가져오기
+        String userIdx =  getMemberByUsername(username).get().getIdx();
+
         // Record 생성 후 저장
         Record record = new Record();
         record.setRecordIdx(String.valueOf(recordIdx)); // 자동 생성된 recordIdx
-        record.setMemberId(userDetails.getUsername());
+        record.setUserIdx(userIdx); // 사용자 userIdx
         record.setTime(time); // 현재 시간
 
         recordRepository.save(record);
-        log.info("Record created: recordIdx={}, memberId={}, time={}", recordIdx, userDetails.getUsername(), time);
+        log.info("Record created: recordIdx={}, userIdx={}, time={}", recordIdx, userIdx, time);
 
         return record;
     }
@@ -106,14 +122,10 @@ public class RecordService {
         }
     }
 
-    public List<Record> getRecordsByUsername(String username) {
-        return recordRepository.findAllByMemberId(username);
-    }
-
     // checked 가 false 인 Record 반환
     public ResponseEntity<?> getUncheckedRecordsByUsername(String username) {
         try {
-            List<Record> records = recordRepository.findAllByMemberIdAndCheckedIsFalse(username);
+            List<Record> records = recordRepository.findAllByUserIdxAndCheckedIsFalse(username);
             log.info("Unchecked Records: {}", records);
 
             if (records.isEmpty()) {
@@ -134,7 +146,10 @@ public class RecordService {
             LocalDateTime startDate = date.atStartOfDay(); // 00:00:00
             LocalDateTime endDate = startDate.plusDays(1); // 다음 날 00:00:00
 
-            List<Record> records = recordRepository.findAllByMemberIdAndDeviceTypeAndResultTimeBetween(username, deviceType, startDate, endDate);
+            // username 으로 member 에서 userIdx(idx) 가져오기
+            String userIdx =  getMemberByUsername(username).get().getIdx();
+
+            List<Record> records = recordRepository.findAllByUserIdxAndDeviceTypeAndTimeBetween(userIdx, deviceType, startDate, endDate);
             log.info("Records by deviceType and date: {}", records);
 
             if (records.isEmpty()) {
@@ -149,17 +164,12 @@ public class RecordService {
     }
 
     // 클라이언트가 알림 확인 시 checked 상태 업데이트
-    public ResponseEntity<?> updateCheckedStatus(CustomUserDetails userDetails, String id) {
+    public ResponseEntity<?> updateCheckedStatus(String username, String id) {
         try {
             Optional<Record> recordOptional = recordRepository.findById(id);
 
             if (recordOptional.isPresent()) {
                 Record record = recordOptional.get();
-
-                // Record의 memberId와 userDetails의 username이 같은지 확인
-                if (!record.getMemberId().equals(userDetails.getUsername())) {
-                    return ResponseEntity.status(403).body("사용자가 일치하지 않습니다.");
-                }
 
                 record.setChecked(true); // checked 상태 업데이트
                 recordRepository.save(record);


### PR DESCRIPTION
1. AiResultDto에서 userIdx 제거
-> 그에 따라 AiResultController에서 userIdx 사용하는 부분 지움
-> websocket 경로에 userIdx 필요 -> recordService.getRecordByRecordIdx 메서드 호출 후 getUserIdx()로 가져옴

2. Record 엔티티에 memberId(=username) 대신 userIdx 추가
-> 그에 따라 RecordRepository에서 findByMemberId 다 지우고 UserIdx로 대체

3. RecordService 수정
	1) fileInput 메서드(음성 -> 백엔드 -> ai 모델)
	-> Record 생성 후 저장 시에 username을 memberId에 저장하던거 지움
	-> customuserdetail에서 가져온 username으로 디비에서 userIdx 가져오는 코드 추가
	-> Record 저장 시에 userIdx 저장 추가
	
	2) getRecordsByDeviceTypeAndDate 메서드(주어진 날짜에서 device 별로 record 반환)
	-> memberId -> userIdx로 대체 (이때 userIdx는 username으로 디비에서 가져옴)


❓  RecordController에서 /input 경로로 음성파일 받아서 ai에게 넘겨줄 때 로그인이 필요한게 아닌데
userDetails 정보가 없어야하지 않나? -> AiResultController 처럼 해야하나?